### PR TITLE
Add and update transport modes  issueNumber #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Douple labels in en and de where changed to alternative terms in de 
 [(#43)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/43)
-- Update a definition mode of transport, air transport, ground transport, motorised transport, water transport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
-- moved motorised transport as subclass of mode of transport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
+- Update a definition mode of transport, air transport, ground transport, water transport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
+- 
 
 ### Removed
+
+- removed motorised transport as subclass of mode of transport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
 
 ## [0.1.0] - 2025-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added MakeFile for automatic building [(#22)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/22) 
 - Added CI for PR validation [(#39)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/39) 
 - Introduction and scope added to README.rst and to the abstract of the ontology. [(#34)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/34)
+- Add a new class rail transport, road rantransport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
 
 ### Changed
 
 - Douple labels in en and de where changed to alternative terms in de 
-[(#30)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/30)
+[(#43)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/43)
+- Update a definition mode of transport, air transport, ground transport, motorised transport, water transport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
+- moved motorised transport as subclass of mode of transport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
+
 ### Removed
 
 ## [0.1.0] - 2025-12-10

--- a/src/ontology/oto.ttl
+++ b/src/ontology/oto.ttl
@@ -1409,23 +1409,15 @@ xsd:string rdf:type rdfs:Datatype .
 ###  http://w3id.org/oto/OTO_00020182
 :OTO_00020182 rdf:type owl:Class ;
               rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000144> ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "A mode of transport is a method or way of traveling, or of transporting people or cargo."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A mode of transport is a method or way of traveling or of transporting participants in a journey."@en ;
               rdfs:label "mode of transport"@en ;
-              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
-
-
-###  http://w3id.org/oto/OTO_00020183
-:OTO_00020183 rdf:type owl:Class ;
-              rdfs:subClassOf :OTO_00020182 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "Motorised Transport is a mode of transport which uses powered propulsion systems for traction.."@en ;
-              rdfs:label "motorised transport"@en ;
               OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
 
 
 ###  http://w3id.org/oto/OTO_00020184
 :OTO_00020184 rdf:type owl:Class ;
               rdfs:subClassOf :OTO_00020182 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> "Air transport is a mode of transport which uses airplanes."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Air transport is a mode of transport which uses air vehicles."@en ;
               <http://purl.obolibrary.org/obo/IAO_0000118> "aviation"@en ;
               rdfs:label "air transport"@en ;
               OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .

--- a/src/ontology/oto.ttl
+++ b/src/ontology/oto.ttl
@@ -60,6 +60,14 @@ dct:title rdf:type owl:AnnotationProperty .
 rdfs:comment rdf:type owl:AnnotationProperty .
 
 
+###  https://openenergyplatform.org/ontology/oeo/OEO_00020426
+OEO:OEO_00020426 rdf:type owl:AnnotationProperty ;
+                 <http://purl.obolibrary.org/obo/IAO_0000115> "Road transport is a mode of transport which uses wheeled vehicles on roads."@en ;
+                 rdfs:label "term tracker annotation"@en ;
+                 OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41" ;
+                 rdfs:subPropertyOf <http://purl.obolibrary.org/obo/IAO_0000116> .
+
+
 #################################################################
 #    Datatypes
 #################################################################
@@ -1401,35 +1409,44 @@ xsd:string rdf:type rdfs:Datatype .
 ###  http://w3id.org/oto/OTO_00020182
 :OTO_00020182 rdf:type owl:Class ;
               rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000144> ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> ""@en ;
-              rdfs:label "mode of transport"@en .
+              <http://purl.obolibrary.org/obo/IAO_0000115> "A mode of transport is a method or way of traveling, or of transporting people or cargo."@en ;
+              rdfs:label "mode of transport"@en ;
+              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
 
 
 ###  http://w3id.org/oto/OTO_00020183
 :OTO_00020183 rdf:type owl:Class ;
-              rdfs:subClassOf <http://purl.obolibrary.org/obo/BFO_0000144> ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> ""@en ;
-              rdfs:label "motorised transport"@en .
+              rdfs:subClassOf :OTO_00020182 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Motorised Transport is a mode of transport which uses powered propulsion systems for traction.."@en ;
+              rdfs:label "motorised transport"@en ;
+              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
 
 
 ###  http://w3id.org/oto/OTO_00020184
 :OTO_00020184 rdf:type owl:Class ;
-              rdfs:subClassOf :OTO_00020183 ;
-              rdfs:label "aviation"@en .
+              rdfs:subClassOf :OTO_00020182 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Air transport is a mode of transport which uses airplanes."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000118> "aviation"@en ;
+              rdfs:label "air transport"@en ;
+              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
 
 
 ###  http://w3id.org/oto/OTO_00020185
 :OTO_00020185 rdf:type owl:Class ;
-              rdfs:subClassOf :OTO_00020183 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> ""@en ;
-              rdfs:label "sea transport"@en .
+              rdfs:subClassOf :OTO_00020182 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Water transport is a mode of transport which occurs on or in water."@en ;
+              <http://purl.obolibrary.org/obo/IAO_0000118> "sea transport"@en ,
+                                                           "ship transport"@en ;
+              rdfs:label "water transport"@en ;
+              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
 
 
 ###  http://w3id.org/oto/OTO_00020186
 :OTO_00020186 rdf:type owl:Class ;
-              rdfs:subClassOf :OTO_00020183 ;
-              <http://purl.obolibrary.org/obo/IAO_0000115> ""@en ;
-              rdfs:label "ground transport"@en .
+              rdfs:subClassOf :OTO_00020182 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Ground transport is a mode of transport which occurs on a solid surface.."@en ;
+              rdfs:label "ground transport"@en ;
+              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
 
 
 ###  http://w3id.org/oto/OTO_00020187
@@ -1582,6 +1599,22 @@ xsd:string rdf:type rdfs:Datatype .
               rdfs:subClassOf :OTO_00020205 ;
               <http://purl.obolibrary.org/obo/IAO_0000115> ""@en ;
               rdfs:label "transport development"@en .
+
+
+###  http://w3id.org/oto/OTO_00020209
+:OTO_00020209 rdf:type owl:Class ;
+              rdfs:subClassOf :OTO_00020182 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Rail transport is a mode of transport which uses wheeled vehicles on rail tracks."@en ;
+              rdfs:label "rail transport"@en ;
+              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41"@en .
+
+
+###  http://w3id.org/oto/OTO_00020210
+:OTO_00020210 rdf:type owl:Class ;
+              rdfs:subClassOf :OTO_00020182 ;
+              <http://purl.obolibrary.org/obo/IAO_0000115> "Road transport is a mode of transport which occurs on roads."@en ;
+              rdfs:label "road transport"@en ;
+              OEO:OEO_00020426 "https://github.com/OpenEnergyPlatform/OpenTransportOntology/issues/41" .
 
 
 ###  Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi


### PR DESCRIPTION
## Summary of the discussion

Describe the findings of the discussion in the issue or meeting.

## Type of change (CHANGELOG.md)

### Added

- Add a new class rail transport, road rantransport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)

### Changed

- Update a definition mode of transport, air transport, ground transport, motorised transport, water transport [(#44)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/44)
- moved motorised transport as subclass of mode of transport 

### Removed

- Remove a broken link [(#)](https://github.com/OpenEnergyPlatform/OpenTransportOntology/pull/)

## Workflow checklist

### Automation

Closes #41

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/OpenTransportOntology/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/OpenTransportOntology/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation
- [x] 🐙 Assign a reviewer to the PR

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/OpenTransportOntology/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
