### PR TITLE
fix release after 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: '*.jar'
-          key: robot-1-9-7-widoco-1-4-25
+          key: robot-1-9-10-widoco-1-4-25
       - name: fetch dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: |
-          wget https://github.com/ontodev/robot/releases/download/v1.9.7/robot.jar -O robot.jar
+          wget https://github.com/ontodev/robot/releases/download/v1.9.10/robot.jar -O robot.jar
           wget https://github.com/dgarijo/Widoco/releases/download/v1.4.25/widoco-1.4.25-jar-with-dependencies_JDK-17.jar -O widoco.jar
       - name: store dependencies
         uses: actions/cache/save@v4

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 ONTOLOGY_NAME := oto
-IRI_NAME := open-transport-ontology
+IRI_NAME := oto
 
+# dont replace IRIs
 IRI_PLACEHOLDER := https:\/\/w3id.org\/
-IRI_BASE := https:\/\/openenergyplatform.github.io\/
+IRI_BASE := https:\/\/w3id.org\/
+#IRI_BASE := https:\/\/openenergyplatform.github.io\/
 
 IRI_ONTOLOGY_PLACEHOLDER := $(IRI_PLACEHOLDER)$(ONTOLOGY_NAME)
 IRI_ONTOLOGY := $(IRI_BASE)$(IRI_NAME)
@@ -158,7 +160,7 @@ $(VERSIONDIR)/catalog-v001.xml: $(ONTOLOGY_SOURCE)/catalog-v001.xml
 	$(SED) -i -E "s/edits\//modules\//m" $@
 
 $(ROBOT_PATH): | build
-	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.9.5/robot.jar
+	curl -L -o $@ https://github.com/ontodev/robot/releases/download/v1.9.10/robot.jar
 
 $(VERSIONDIR)/owl/%.owl: $(VERSIONDIR)/%.ttl
 	$(call translate_to_owl,$@,$<)


### PR DESCRIPTION
## Summary of the discussion

during the release of 0.2.0 a `Makefile` was introduced.
Some of the assumptions in there, did not comply with the development structure, so the resulting release was messed up

1. the release contains a file `src/OTO.owl` which includes OEO contents
2. the namespace of IRIs in the released files was rewritten to github.io URLs

this pull request currently fixes the 2nd issue.
still investigating the first one.

## Type of change (CHANGELOG.md)

*[ omitted as this refers to infrastructure only]*

## Workflow checklist

### Automation

Part of # / Closes #

### PR-Assignee

- [ ] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/open-transport-ontology/blob/production/CONTRIBUTING.md)
- [ ] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/open-transport-ontology/blob/develop/CHANGELOG.md)
- [ ] 📙 Update the documentation
- [ ] 🐙 Assign a reviewer to the PR

### Reviewer

- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/open-transport-ontology/blob/production/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
